### PR TITLE
ASM-8364 Add Intel X710 NIC to undinet_irq_is_broken

### DIFF
--- a/src/arch/x86/drivers/net/undinet.c
+++ b/src/arch/x86/drivers/net/undinet.c
@@ -593,6 +593,8 @@ static const struct undinet_irq_broken undinet_irq_broken_list[] = {
 	{ .pci_vendor = 0x8086, .pci_device = 0x1503 },
 	/* HP 745 G3 laptop */
 	{ .pci_vendor = 0x14e4, .pci_device = 0x1687 },
+	/* Intel X710 10G NIC */
+	{ .pci_vendor = 0x8086, .pci_device = 0x1581 },
 };
 
 /**


### PR DESCRIPTION
Random network hangs were being seen on Intel X710 NICs both while
using undionly and ISO ipxe boot. Comments on the ipxe developer
mailing list thread "SuperMicro SYS-1028U-TR+ with Intel X710-DR2 nic
card" indicated that the NIC driver might have a bug that causes it to
"lose an interrupt, which effectively kills the receive datapath." and
suggested adding the NIC to list of NICs that report true for
undinet_irq_is_broken. Indeed this does seem to resolve the issue.

Note that commit 3bb61c33c2d77ac9a1a512d809576f3444b6b1ed also seems
to resolve the network hang issue inadvertently by disabling IRQs for
an unrelated reason. However that change has the strange unwanted
side-effect of breaking e.g. pxelinux.0 boot during ESXi
installs. Adding the Intel X710 NIC to the undinet_irq_is_broken list
seems to resolve both issues.