### PR TITLE
ASM-8364 Add Intel X710 NIC variants to undinet_irq_is_broken

### DIFF
--- a/src/arch/x86/drivers/net/undinet.c
+++ b/src/arch/x86/drivers/net/undinet.c
@@ -593,8 +593,16 @@ static const struct undinet_irq_broken undinet_irq_broken_list[] = {
 	{ .pci_vendor = 0x8086, .pci_device = 0x1503 },
 	/* HP 745 G3 laptop */
 	{ .pci_vendor = 0x14e4, .pci_device = 0x1687 },
-	/* Intel X710 10G NIC */
-	{ .pci_vendor = 0x8086, .pci_device = 0x1581 },
+        /* Ethernet Controller X710 for 10GbE SFP+ */
+        { .pci_vendor = 0x8086, .pci_device = 0x1572 },
+        /* Ethernet Controller X710 for 10GbE backplane */
+        { .pci_vendor = 0x8086, .pci_device = 0x1581 },
+        /* Ethernet Controller X710 for 10GbE QSFP+ */
+        { .pci_vendor = 0x8086, .pci_device = 0x1585 },
+        /* Ethernet Controller X710 for 10GBASE-T */
+        { .pci_vendor = 0x8086, .pci_device = 0x1586 },
+        /* Ethernet Controller X710/X557-AT 10GBASE-T */
+        { .pci_vendor = 0x8086, .pci_device = 0x1589 },
 };
 
 /**


### PR DESCRIPTION
Intel X710 NICs seem to have broken IRQ handling behavior. Commit
6d387f1ce9ffcbd363b93bc9697574814ec81a42 added one X710 variant to
undinet_irq_is_broken but missed other variants. This change adds the
full list of X710 device taken from the linux kernel x710 driver
source code.